### PR TITLE
Add ProcessoXml storage entity

### DIFF
--- a/src/main/java/br/jus/cnj/datajud/elasticToDatajud/model/ProcessoXml.java
+++ b/src/main/java/br/jus/cnj/datajud/elasticToDatajud/model/ProcessoXml.java
@@ -1,0 +1,64 @@
+package br.jus.cnj.datajud.elasticToDatajud.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "processo_xml")
+public class ProcessoXml implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @SequenceGenerator(name = "gen_processo_xml", sequenceName = "sq_processo_xml", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gen_processo_xml")
+    private Long id;
+
+    @Column(name = "sigla_tribunal")
+    private String siglaTribunal;
+
+    @Column(name = "millisinsercao")
+    private Long millisInsercao;
+
+    @Column(name = "xml")
+    private String xml;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSiglaTribunal() {
+        return siglaTribunal;
+    }
+
+    public void setSiglaTribunal(String siglaTribunal) {
+        this.siglaTribunal = siglaTribunal;
+    }
+
+    public Long getMillisInsercao() {
+        return millisInsercao;
+    }
+
+    public void setMillisInsercao(Long millisInsercao) {
+        this.millisInsercao = millisInsercao;
+    }
+
+    public String getXml() {
+        return xml;
+    }
+
+    public void setXml(String xml) {
+        this.xml = xml;
+    }
+}

--- a/src/main/java/br/jus/cnj/datajud/elasticToDatajud/repository/ProcessoXmlRepository.java
+++ b/src/main/java/br/jus/cnj/datajud/elasticToDatajud/repository/ProcessoXmlRepository.java
@@ -1,0 +1,26 @@
+package br.jus.cnj.datajud.elasticToDatajud.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import br.jus.cnj.datajud.elasticToDatajud.model.ProcessoXml;
+
+@Repository
+public interface ProcessoXmlRepository extends JpaRepository<ProcessoXml, Long> {
+
+    @Query("select o from ProcessoXml o where o.siglaTribunal = :siglaTribunal and o.millisInsercao >= :inicio and o.millisInsercao <= :fim order by o.millisInsercao")
+    List<ProcessoXml> findBySiglaTribunalAndMillisInsercaoBetween(@Param("siglaTribunal") String siglaTribunal,
+                                                                  @Param("inicio") Long inicio,
+                                                                  @Param("fim") Long fim,
+                                                                  Pageable pageable);
+
+    @Query("select count(o) from ProcessoXml o where o.siglaTribunal = :siglaTribunal and o.millisInsercao >= :inicio and o.millisInsercao <= :fim")
+    long countBySiglaTribunalAndMillisInsercaoBetween(@Param("siglaTribunal") String siglaTribunal,
+                                                      @Param("inicio") Long inicio,
+                                                      @Param("fim") Long fim);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,7 @@ postgresqlPwd=postgres
 elasticsearchHost=api.datajud.cnj.jus.br
 elasticsearchPort=443
 elasticsearchUser=
-elasticsearchPwd=
-millisInsercao=0
+elasticsearchPwd=millisInsercao=0
+xmlPostgresqlUrl=jdbc:postgresql://localhost:5432/datajud_xml
+xmlPostgresqlUser=postgres
+xmlPostgresqlPwd=postgres


### PR DESCRIPTION
## Summary
- create `ProcessoXml` entity to map XML table
- add `ProcessoXmlRepository` with range queries and count support
- extend `application.properties` with separate XML database properties

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d59936238832abea3fcc71bd688ce