### PR TITLE
Add XmlProcessParser utility

### DIFF
--- a/src/main/java/br/jus/cnj/datajud/elasticToDatajud/util/XmlProcessParser.java
+++ b/src/main/java/br/jus/cnj/datajud/elasticToDatajud/util/XmlProcessParser.java
@@ -1,0 +1,38 @@
+package br.jus.cnj.datajud.elasticToDatajud.util;
+
+import org.json.JSONObject;
+import org.json.XML;
+
+/**
+ * Utility class to convert XML strings representing a process to
+ * {@link JSONObject} instances used by the consolidator services.
+ */
+public class XmlProcessParser {
+
+    private XmlProcessParser() {
+        // utility class
+    }
+
+    /**
+     * Converts the provided XML string to a {@link JSONObject}. If the
+     * resulting object contains a single root element it will be unwrapped so
+     * the returned object contains the expected process attributes directly.
+     *
+     * @param xml XML representation of the process
+     * @return JSONObject with the process data
+     */
+    public static JSONObject parse(String xml) {
+        if (xml == null || xml.trim().isEmpty()) {
+            throw new IllegalArgumentException("XML string is empty");
+        }
+        JSONObject json = XML.toJSONObject(xml);
+        if (json.length() == 1) {
+            String key = json.keys().next();
+            Object val = json.get(key);
+            if (val instanceof JSONObject) {
+                json = (JSONObject) val;
+            }
+        }
+        return json;
+    }
+}

--- a/src/test/java/br/jus/cnj/datajud/elasticToDatajud/util/XmlProcessParserTest.java
+++ b/src/test/java/br/jus/cnj/datajud/elasticToDatajud/util/XmlProcessParserTest.java
@@ -1,0 +1,30 @@
+package br.jus.cnj.datajud.elasticToDatajud.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link XmlProcessParser}.
+ */
+public class XmlProcessParserTest {
+
+    @Test
+    public void testParseSimpleXml() {
+        String xml = "<processo>" +
+                "<grau>1</grau>" +
+                "<siglaTribunal>TJ</siglaTribunal>" +
+                "<dadosBasicos><numero>0001</numero></dadosBasicos>" +
+                "<movimento><id>5</id></movimento>" +
+                "</processo>";
+
+        JSONObject obj = XmlProcessParser.parse(xml);
+
+        assertEquals("0001", obj.getJSONObject("dadosBasicos").getString("numero"));
+        assertEquals("1", obj.getString("grau"));
+        assertEquals("TJ", obj.getString("siglaTribunal"));
+        assertTrue(obj.has("movimento"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `XmlProcessParser` utility to convert XML strings to `JSONObject`
- add unit tests for the parser

## Testing
- `mvn test` *(fails: Maven wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d5c934b54832a860a556891405a03