### PR TITLE
Add HML extraction and indicator calculator

### DIFF
--- a/DB/postgres/create_indicadores_historico.sql
+++ b/DB/postgres/create_indicadores_historico.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS indicadores_historico (
+    id SERIAL PRIMARY KEY,
+    nr_processo      VARCHAR(30),
+    indicador        VARCHAR(50),
+    valor            NUMERIC,
+    data_calculo     DATE DEFAULT CURRENT_DATE
+);

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Em seguida execute os comandos abaixo:
 
 Durante a execução o sistema extrai os XMLs, realiza o parsing das informações, grava nas tabelas normalizadas e, por fim, calcula os indicadores. O tempo de conclusão é proporcional à capacidade de processamento da estação.
 
+## Extração direta do datajud_hml
+
+Para calcular os indicadores a partir do banco `datajud_hml` sem utilizar o Elastic, execute:
+
+```
+java -cp target/elastictodatajud-0.0.1-SNAPSHOT.jar br.jus.cnj.datajud.hml.HmlIndicatorsApplication
+```
+
+O aplicativo utilizará as variáveis de ambiente `hmlPostgresqlUrl`, `hmlPostgresqlUser` e `hmlPostgresqlPwd` para acessar o banco, extraindo os XMLs enviados entre `01/08/2024` e `31/07/2025` e apresentando os indicadores I, III e V da Portaria CNJ 238/2024.
+
+
 ## Suporte
 A definir
 

--- a/datamart-to-bi-master/create_view_indicadores.R
+++ b/datamart-to-bi-master/create_view_indicadores.R
@@ -1,0 +1,21 @@
+# Cria view persistente com os indicadores calculados a partir do datamart
+source('VarAmbiente.R', encoding = 'latin1')
+source('PacotesFuncoes.R', encoding = 'latin1')
+
+library(RPostgres)
+
+con <- dbConnect(RPostgres::Postgres(),
+                 dbname   = db,
+                 host     = host_db,
+                 port     = db_port,
+                 user     = db_user,
+                 password = db_password)
+
+# Exemplo simples de criacao de view utilizando a tabela fato dos processos
+query <- "CREATE OR REPLACE VIEW vw_processos_indicadores AS\n";
+query <- paste0(query, "SELECT id_processo, indicador, valor, data_calculo\n",
+                "FROM indicadores_historico;")
+
+try(dbExecute(con, query))
+
+dbDisconnect(con)

--- a/src/main/java/br/jus/cnj/datajud/hml/HmlIndicatorsApplication.java
+++ b/src/main/java/br/jus/cnj/datajud/hml/HmlIndicatorsApplication.java
@@ -1,0 +1,29 @@
+package br.jus.cnj.datajud.hml;
+
+import br.jus.cnj.datajud.indicator.IndicatorCalculator;
+import br.jus.cnj.datajud.indicator.IndicatorResult;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Aplicacao simples para extracao de XMLs do banco datajud_hml e calculo
+ * dos indicadores I, III e V da Portaria CNJ 238/2024.
+ */
+public class HmlIndicatorsApplication {
+
+    public static void main(String[] args) throws SQLException {
+        String url = System.getenv().getOrDefault("hmlPostgresqlUrl", "jdbc:postgresql://localhost:5432/datajud_hml");
+        String user = System.getenv().getOrDefault("hmlPostgresqlUser", "postgres");
+        String pwd = System.getenv().getOrDefault("hmlPostgresqlPwd", "postgres");
+
+        HmlXmlExtractor extractor = new HmlXmlExtractor(url, user, pwd);
+        LocalDateTime ini = LocalDateTime.of(2024, 8, 1, 0, 0);
+        LocalDateTime fim = LocalDateTime.of(2025, 7, 31, 23, 59);
+        List<XmlRecord> registros = extractor.fetchXmls(ini, fim);
+
+        IndicatorCalculator calc = new IndicatorCalculator();
+        IndicatorResult result = calc.calculate(registros);
+        System.out.println(result);
+    }
+}

--- a/src/main/java/br/jus/cnj/datajud/hml/HmlXmlExtractor.java
+++ b/src/main/java/br/jus/cnj/datajud/hml/HmlXmlExtractor.java
@@ -1,0 +1,63 @@
+package br.jus.cnj.datajud.hml;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Responsável por extrair os XMLs diretamente do banco {@code datajud_hml}.
+ */
+public class HmlXmlExtractor {
+
+    private final String url;
+    private final String user;
+    private final String pwd;
+
+    public HmlXmlExtractor(String url, String user, String pwd) {
+        this.url = url;
+        this.user = user;
+        this.pwd = pwd;
+    }
+
+    /**
+     * Busca os XMLs dos processos no período informado.
+     *
+     * @param inicio data inicial
+     * @param fim data final
+     * @return lista de registros
+     */
+    public List<XmlRecord> fetchXmls(LocalDateTime inicio, LocalDateTime fim) throws SQLException {
+        List<XmlRecord> lista = new ArrayList<>();
+        String sql = "SELECT chave.nr_processo, chave.cd_classe_judicial, chave.nm_grau," +
+                " chave.cd_orgao_julgador, lote.dh_envio_local," +
+                " convert_from(xml.conteudo_xml, 'UTF8') AS xml_text" +
+                " FROM datajud_hml.tb_lote_processo lote" +
+                " JOIN datajud_hml.tb_chave_processo_cnj chave ON lote.id_chave_processo_cnj = chave.id_chave_processo_cnj" +
+                " JOIN datajud_hml.tb_xml_processo xml ON lote.id_xml_processo = xml.id_xml_processo" +
+                " WHERE lote.dh_envio_local BETWEEN ? AND ?"; 
+        try (Connection con = DriverManager.getConnection(url, user, pwd); 
+             PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setTimestamp(1, Timestamp.valueOf(inicio));
+            ps.setTimestamp(2, Timestamp.valueOf(fim));
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    XmlRecord r = new XmlRecord();
+                    r.setNumeroProcesso(rs.getString(1));
+                    r.setCdClasseJudicial(rs.getInt(2));
+                    r.setGrau(rs.getInt(3));
+                    r.setCdOrgaoJulgador(rs.getInt(4));
+                    r.setDataEnvio(rs.getTimestamp(5));
+                    r.setXml(rs.getString(6));
+                    lista.add(r);
+                }
+            }
+        }
+        return lista;
+    }
+}

--- a/src/main/java/br/jus/cnj/datajud/hml/XmlRecord.java
+++ b/src/main/java/br/jus/cnj/datajud/hml/XmlRecord.java
@@ -1,0 +1,63 @@
+package br.jus.cnj.datajud.hml;
+
+import java.sql.Timestamp;
+
+/**
+ * Representa um registro de XML proveniente do banco datajud_hml.
+ */
+public class XmlRecord {
+    private String numeroProcesso;
+    private Integer cdClasseJudicial;
+    private Integer grau;
+    private Integer cdOrgaoJulgador;
+    private Timestamp dataEnvio;
+    private String xml;
+
+    public String getNumeroProcesso() {
+        return numeroProcesso;
+    }
+
+    public void setNumeroProcesso(String numeroProcesso) {
+        this.numeroProcesso = numeroProcesso;
+    }
+
+    public Integer getCdClasseJudicial() {
+        return cdClasseJudicial;
+    }
+
+    public void setCdClasseJudicial(Integer cdClasseJudicial) {
+        this.cdClasseJudicial = cdClasseJudicial;
+    }
+
+    public Integer getGrau() {
+        return grau;
+    }
+
+    public void setGrau(Integer grau) {
+        this.grau = grau;
+    }
+
+    public Integer getCdOrgaoJulgador() {
+        return cdOrgaoJulgador;
+    }
+
+    public void setCdOrgaoJulgador(Integer cdOrgaoJulgador) {
+        this.cdOrgaoJulgador = cdOrgaoJulgador;
+    }
+
+    public Timestamp getDataEnvio() {
+        return dataEnvio;
+    }
+
+    public void setDataEnvio(Timestamp dataEnvio) {
+        this.dataEnvio = dataEnvio;
+    }
+
+    public String getXml() {
+        return xml;
+    }
+
+    public void setXml(String xml) {
+        this.xml = xml;
+    }
+}

--- a/src/main/java/br/jus/cnj/datajud/indicator/IndicatorCalculator.java
+++ b/src/main/java/br/jus/cnj/datajud/indicator/IndicatorCalculator.java
@@ -1,0 +1,65 @@
+package br.jus.cnj.datajud.indicator;
+
+import br.jus.cnj.datajud.hml.XmlRecord;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Cálculo simplificado dos indicadores da Portaria CNJ 238/2024.
+ * Esta implementação faz apenas uma contagem básica de sentenças e decisões
+ * homologatórias nos XMLs extraídos.
+ */
+public class IndicatorCalculator {
+
+    public IndicatorResult calculate(List<XmlRecord> registros) {
+        int sentCHNcrim1 = 0;
+        int sentCNcrim1 = 0;
+        int decHCNcrim2 = 0;
+        int decCNcrim2 = 0;
+        int sentJudNcrimH1 = 0;
+        int sentJudNcrimHJE = 0;
+        int sentJudNcrim1 = 0;
+        int sentJudNCrimJE = 0;
+
+        for (XmlRecord r : registros) {
+            String xml = r.getXml();
+            if (xml == null) {
+                continue;
+            }
+            String upper = xml.toUpperCase(Locale.ROOT);
+            boolean homologatoria = upper.contains("HOMOLOGA");
+            boolean execucao = upper.contains("EXECUCAO") || upper.contains("CUMPRIMENTO");
+            if (r.getGrau() != null && r.getGrau() == 1) {
+                sentCNcrim1++;
+                if (homologatoria) {
+                    sentCHNcrim1++;
+                }
+                if (execucao) {
+                    sentJudNcrim1++;
+                    if (homologatoria) {
+                        sentJudNcrimH1++;
+                    }
+                }
+            } else if (r.getGrau() != null && r.getGrau() == 2) {
+                decCNcrim2++;
+                if (homologatoria) {
+                    decHCNcrim2++;
+                }
+                if (execucao) {
+                    sentJudNCrimJE++;
+                    if (homologatoria) {
+                        sentJudNcrimHJE++;
+                    }
+                }
+            }
+        }
+
+        IndicatorResult result = new IndicatorResult();
+        result.setIndicadorI(sentCNcrim1 == 0 ? 0.0 : (double) sentCHNcrim1 / sentCNcrim1);
+        result.setIndicadorIII(decCNcrim2 == 0 ? 0.0 : (double) decHCNcrim2 / decCNcrim2);
+        int totalSentJud = sentJudNcrim1 + sentJudNCrimJE;
+        int totalHomolog = sentJudNcrimH1 + sentJudNcrimHJE;
+        result.setIndicadorV(totalSentJud == 0 ? 0.0 : (double) totalHomolog / totalSentJud);
+        return result;
+    }
+}

--- a/src/main/java/br/jus/cnj/datajud/indicator/IndicatorResult.java
+++ b/src/main/java/br/jus/cnj/datajud/indicator/IndicatorResult.java
@@ -1,0 +1,43 @@
+package br.jus.cnj.datajud.indicator;
+
+/**
+ * Resultado do cálculo dos indicadores definidos na Portaria CNJ 238/2024.
+ */
+public class IndicatorResult {
+    private double indicadorI;
+    private double indicadorIII;
+    private double indicadorV;
+
+    public double getIndicadorI() {
+        return indicadorI;
+    }
+
+    public void setIndicadorI(double indicadorI) {
+        this.indicadorI = indicadorI;
+    }
+
+    public double getIndicadorIII() {
+        return indicadorIII;
+    }
+
+    public void setIndicadorIII(double indicadorIII) {
+        this.indicadorIII = indicadorIII;
+    }
+
+    public double getIndicadorV() {
+        return indicadorV;
+    }
+
+    public void setIndicadorV(double indicadorV) {
+        this.indicadorV = indicadorV;
+    }
+
+    @Override
+    public String toString() {
+        return "IndicatorResult{" +
+                "indicadorI=" + indicadorI +
+                ", indicadorIII=" + indicadorIII +
+                ", indicadorV=" + indicadorV +
+                '}';
+    }
+}


### PR DESCRIPTION
## Summary
- create SQL for `indicadores_historico`
- add R script to create view for indicadores
- implement Java utilities to extract XML directly from `datajud_hml`
- calculate simplified indicators I, III and V from Portaria 238/2024
- document how to run the new application

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d64c1f588832aa0bffdd29d46be99