### PR TITLE
Add database initialization scripts

### DIFF
--- a/DB/Dockerfile
+++ b/DB/Dockerfile
@@ -1,5 +1,7 @@
 FROM postgres:alpine
-ADD scripts/structure.sql /docker-entrypoint-initdb.d
-ADD scripts/data.sql /docker-entrypoint-initdb.d
+ADD postgres/init.sql /docker-entrypoint-initdb.d/
+ADD postgres/structure.sql /docker-entrypoint-initdb.d/
+ADD postgres/data.sql /docker-entrypoint-initdb.d/
+ADD postgres/create_indicadores_historico.sql /docker-entrypoint-initdb.d/
 RUN chmod a+r /docker-entrypoint-initdb.d/*
-EXPOSE 6666
+EXPOSE 5432

--- a/DB/docker-compose.yml
+++ b/DB/docker-compose.yml
@@ -15,3 +15,7 @@ services:
     volumes:
       - ./postgres/data:/var/lib/postgresql/data
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./postgres/structure.sql:/docker-entrypoint-initdb.d/structure.sql
+      - ./postgres/data.sql:/docker-entrypoint-initdb.d/data.sql
+      - ./postgres/create_indicadores_historico.sql:/docker-entrypoint-initdb.d/create_indicadores_historico.sql
+

--- a/DB/postgres/data.sql
+++ b/DB/postgres/data.sql
@@ -1,0 +1,3 @@
+-- Insere dados de exemplo
+INSERT INTO datamart.indicadores_historico (nr_processo, indicador, valor)
+VALUES ('0000000-00.0000.0.00.0000', 'exemplo', 0);

--- a/DB/postgres/init.sql
+++ b/DB/postgres/init.sql
@@ -1,0 +1,3 @@
+-- Executado automaticamente pelo container PostgreSQL
+\i /docker-entrypoint-initdb.d/structure.sql
+\i /docker-entrypoint-initdb.d/data.sql

--- a/DB/postgres/structure.sql
+++ b/DB/postgres/structure.sql
@@ -1,0 +1,6 @@
+-- Cria o schema do datamart
+CREATE SCHEMA IF NOT EXISTS datamart;
+SET search_path TO datamart;
+
+-- Tabelas iniciais
+\i /docker-entrypoint-initdb.d/create_indicadores_historico.sql

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ docker-compose up -d
 ```
 
 O Docker cria o banco datamart e popula as tabelas iniciais.
+Todos os arquivos `.sql` presentes em `DB/postgres` são montados no
+diretório `/docker-entrypoint-initdb.d` do contêiner. O script
+`init.sql` executa `structure.sql` e `data.sql`, que por sua vez criam o
+schema `datamart` e inserem dados básicos. Assim a estrutura do banco
+é criada automaticamente na primeira inicialização.
 
 3. **Defina as variáveis de ambiente**
 


### PR DESCRIPTION
## Summary
- add init.sql, structure.sql and data.sql to DB/postgres
- copy SQL scripts in DB/Dockerfile
- mount scripts in docker-compose.yml
- document initialization procedure in README

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fcf7e3d38832a892b2c8f2df7c163